### PR TITLE
Modify query path to return only aggregate subject info

### DIFF
--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -75,23 +75,27 @@ async def get(
     ]
     results_df = pd.DataFrame(results_dicts)
 
-    agg_dicts = (
-        []
-        if results_df.empty
-        else results_df.groupby(by=["dataset", "dataset_name"])
-        .size()
-        .reset_index(name="subjects")
-        .sort_values(by=["dataset_name"])
-        .to_dict("records")
-    )
-
-    response_obj = [
-        AggDatasetResponse(
-            dataset=i["dataset"],
-            dataset_name=i["dataset_name"],
-            num_matching_subjects=i["subjects"],
+    if results_df.empty:
+        response_obj = [
+            AggDatasetResponse(
+                num_matching_subjects=results_df.squeeze().shape[0]
+            )
+        ]
+    else:
+        agg_dicts = (
+            results_df.groupby(by=["dataset", "dataset_name"])
+            .size()
+            .reset_index(name="num_subjects")
+            .sort_values(by="dataset_name")
+            .to_dict("records")
         )
-        for i in agg_dicts
-    ]
+        response_obj = [
+            AggDatasetResponse(
+                dataset=i["dataset"],
+                dataset_name=i["dataset_name"],
+                num_matching_subjects=i["num_subjects"],
+            )
+            for i in agg_dicts
+        ]
 
     return response_obj

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -68,34 +68,23 @@ async def get(
 
     results = response.json()
 
-    # return results
     results_dicts = [
         {k: v["value"] for k, v in res.items()}
         for res in results["results"]["bindings"]
     ]
     results_df = pd.DataFrame(results_dicts)
 
-    if results_df.empty:
-        response_obj = [
-            AggDatasetResponse(
-                num_matching_subjects=results_df.squeeze().shape[0]
+    response_obj = []
+    if not results_df.empty:
+        for (dataset, dataset_name), group in results_df.groupby(
+            by=["dataset", "dataset_name"]
+        ):
+            response_obj.append(
+                AggDatasetResponse(
+                    dataset=dataset,
+                    dataset_name=dataset_name,
+                    num_matching_subjects=group.shape[0],
+                )
             )
-        ]
-    else:
-        agg_dicts = (
-            results_df.groupby(by=["dataset", "dataset_name"])
-            .size()
-            .reset_index(name="num_subjects")
-            .sort_values(by="dataset_name")
-            .to_dict("records")
-        )
-        response_obj = [
-            AggDatasetResponse(
-                dataset=i["dataset"],
-                dataset_name=i["dataset_name"],
-                num_matching_subjects=i["num_subjects"],
-            )
-            for i in agg_dicts
-        ]
 
     return response_obj

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -75,9 +75,23 @@ async def get(
     ]
     results_df = pd.DataFrame(results_dicts)
 
-    # .squeeze() is needed below for case where results_dict contains a [{}] (GROUP BY behaviour)
+    agg_dicts = (
+        []
+        if results_df.empty
+        else results_df.groupby(by=["dataset", "dataset_name"])
+        .size()
+        .reset_index(name="subjects")
+        .sort_values(by=["dataset_name"])
+        .to_dict("records")
+    )
+
     response_obj = [
-        AggDatasetResponse(num_matching_subjects=results_df.squeeze().shape[0])
+        AggDatasetResponse(
+            dataset=i["dataset"],
+            dataset_name=i["dataset_name"],
+            num_matching_subjects=i["subjects"],
+        )
+        for i in agg_dicts
     ]
 
     return response_obj

--- a/app/api/crud.py
+++ b/app/api/crud.py
@@ -2,9 +2,11 @@
 import os
 
 import httpx
+import pandas as pd
 from fastapi import HTTPException
 
 from . import utility as util
+from .models import AggDatasetResponse
 
 
 async def get(
@@ -66,7 +68,16 @@ async def get(
 
     results = response.json()
 
-    return [
+    # return results
+    results_dicts = [
         {k: v["value"] for k, v in res.items()}
         for res in results["results"]["bindings"]
     ]
+    results_df = pd.DataFrame(results_dicts)
+
+    # .squeeze() is needed below for case where results_dict contains a [{}] (GROUP BY behaviour)
+    response_obj = [
+        AggDatasetResponse(num_matching_subjects=results_df.squeeze().shape[0])
+    ]
+
+    return response_obj

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -45,3 +45,9 @@ class QueryModel(BaseModel):
                 detail="Subjects cannot both be healthy controls and have a diagnosis.",
             )
         return values
+
+
+class AggDatasetResponse(BaseModel):
+    dataset: str = None
+    dataset_name: str = None
+    num_matching_subjects: int

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -50,6 +50,6 @@ class QueryModel(BaseModel):
 class AggDatasetResponse(BaseModel):
     """Data model for query results aggregated at the dataset-level."""
 
-    dataset: str = None
-    dataset_name: str = None
+    dataset: str
+    dataset_name: str
     num_matching_subjects: int

--- a/app/api/models.py
+++ b/app/api/models.py
@@ -48,6 +48,8 @@ class QueryModel(BaseModel):
 
 
 class AggDatasetResponse(BaseModel):
+    """Data model for query results aggregated at the dataset-level."""
+
     dataset: str = None
     dataset_name: str = None
     num_matching_subjects: int

--- a/app/api/routers/query.py
+++ b/app/api/routers/query.py
@@ -1,16 +1,18 @@
 """Router for query path operations."""
 
+from typing import List
+
 from fastapi import APIRouter, Depends
 
 from .. import crud
-from ..models import QueryModel
+from ..models import AggDatasetResponse, QueryModel
 
 router = APIRouter(prefix="/query", tags=["query"])
 
 
-@router.get("/")
+@router.get("/", response_model=List[AggDatasetResponse])
 async def get_query(query: QueryModel = Depends(QueryModel)):
-    """When a GET request is sent, return list of dicts corresponding to subject-level metadata."""
+    """When a GET request is sent, return list of dicts corresponding to subject-level metadata aggregated by dataset."""
     response = await crud.get(
         query.age_min,
         query.age_max,

--- a/app/api/utility.py
+++ b/app/api/utility.py
@@ -107,6 +107,8 @@ def create_query(
     query_template = f"""
     {DEFAULT_CONTEXT}
 
+    SELECT ?dataset ?dataset_name ?sub_id
+    WHERE {{
     SELECT DISTINCT ?dataset ?dataset_name ?subject ?sub_id ?age ?sex
     ?diagnosis ?image_modal ?num_sessions
     WHERE {{
@@ -133,6 +135,8 @@ def create_query(
     }}
 
     {subject_level_filters}
-}}"""
+}}
+}} GROUP BY ?dataset ?dataset_name ?sub_id
+"""
 
     return query_template

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ idna==3.4
 iniconfig==1.1.1
 nodeenv==1.7.0
 packaging==21.3
+pandas==1.5.2
 platformdirs==2.5.4
 pluggy==1.0.0
 pre-commit==2.20.0

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -70,12 +70,12 @@ def test_app_with_invalid_environment_vars(test_app, monkeypatch):
 
 
 def test_get_all(test_app, mock_successful_get, monkeypatch):
-    """Given no input for the sex parameter, returns a 200 status code and at least one dataset with subjects (should correspond to all subjects in graph)."""
+    """Given no input for the sex parameter, returns a 200 status code and a non-empty list of results (should correspond to all subjects in graph)."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get("/query/")
     assert response.status_code == 200
-    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
+    assert response.json() != []
 
 
 @pytest.mark.parametrize(
@@ -85,14 +85,14 @@ def test_get_all(test_app, mock_successful_get, monkeypatch):
 def test_get_valid_age_range(
     test_app, mock_successful_get, valid_age_min, valid_age_max, monkeypatch
 ):
-    """Given a valid age range, returns a 200 status code and at least one dataset with subjects."""
+    """Given a valid age range, returns a 200 status code and a non-empty list of results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(
         f"/query/?age_min={valid_age_min}&age_max={valid_age_max}"
     )
     assert response.status_code == 200
-    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
+    assert response.json() != []
 
 
 @pytest.mark.parametrize(
@@ -102,12 +102,12 @@ def test_get_valid_age_range(
 def test_get_valid_age_single_bound(
     test_app, mock_successful_get, age_keyval, monkeypatch
 ):
-    """Given only a valid lower/upper age bound, returns a 200 status code and at least one dataset with subjects."""
+    """Given only a valid lower/upper age bound, returns a 200 status code and a non-empty list of results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?{age_keyval}")
     assert response.status_code == 200
-    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
+    assert response.json() != []
 
 
 @pytest.mark.parametrize(
@@ -143,12 +143,12 @@ def test_get_invalid_age(
 
 @pytest.mark.parametrize("valid_sex", ["male", "female", "other"])
 def test_get_valid_sex(test_app, mock_successful_get, valid_sex, monkeypatch):
-    """Given a valid sex string, returns a 200 status code and at least one dataset with subjects."""
+    """Given a valid sex string, returns a 200 status code and a non-empty list of results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?sex={valid_sex}")
     assert response.status_code == 200
-    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
+    assert response.json() != []
 
 
 def test_get_invalid_sex(test_app, monkeypatch):
@@ -176,12 +176,12 @@ def test_get_invalid_sex(test_app, monkeypatch):
 def test_get_valid_diagnosis(
     test_app, mock_successful_get, valid_diagnosis, monkeypatch
 ):
-    """Given a valid diagnosis, returns a 200 status code and at least one dataset with subjects."""
+    """Given a valid diagnosis, returns a 200 status code and a non-empty list results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?diagnosis={valid_diagnosis}")
     assert response.status_code == 200
-    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
+    assert response.json() != []
 
 
 @pytest.mark.parametrize(
@@ -210,12 +210,12 @@ def test_get_invalid_diagnosis(test_app, invalid_diagnosis, monkeypatch):
 def test_get_valid_iscontrol(
     test_app, mock_successful_get, valid_iscontrol, monkeypatch
 ):
-    """Given a valid is_control value, returns a 200 status code and at least one dataset with subjects."""
+    """Given a valid is_control value, returns a 200 status code and a non-empty list of results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?is_control={valid_iscontrol}")
     assert response.status_code == 200
-    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
+    assert response.json() != []
 
 
 def test_get_invalid_iscontrol(test_app, monkeypatch):
@@ -266,14 +266,14 @@ def test_get_invalid_control_diagnosis_pair(test_app, monkeypatch):
 def test_get_valid_min_num_sessions(
     test_app, mock_successful_get, valid_min_num_sessions, monkeypatch
 ):
-    """Given a valid minimum number of imaging sessions, returns a 200 status code and at least one dataset with subjects."""
+    """Given a valid minimum number of imaging sessions, returns a 200 status code and a non-empty list of results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(
         f"/query/?min_num_sessions={valid_min_num_sessions}"
     )
     assert response.status_code == 200
-    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
+    assert response.json() != []
 
 
 @pytest.mark.parametrize("invalid_min_num_sessions", [0, -3, "apple"])
@@ -313,14 +313,14 @@ def test_get_invalid_min_num_sessions(
 def test_get_valid_available_image_modal(
     test_app, mock_successful_get, valid_available_image_modal, monkeypatch
 ):
-    """Given a valid and available image modality, returns a 200 status code and at least one dataset with subjects."""
+    """Given a valid and available image modality, returns a 200 status code and a non-empty list of results."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(
         f"/query/?image_modal={valid_available_image_modal}"
     )
     assert response.status_code == 200
-    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
+    assert response.json() != []
 
 
 @pytest.mark.parametrize(
@@ -330,7 +330,7 @@ def test_get_valid_available_image_modal(
 def test_get_valid_unavailable_image_modal(
     test_app, valid_unavailable_image_modal, monkeypatch
 ):
-    """Given a valid, pre-defined, and unavailable image modality, returns a 200 status code and 0 matching subjects."""
+    """Given a valid, pre-defined, and unavailable image modality, returns a 200 status code and an empty list of results."""
 
     async def mock_get(
         age_min,
@@ -347,8 +347,6 @@ def test_get_valid_unavailable_image_modal(
     response = test_app.get(
         f"/query/?image_modal={valid_unavailable_image_modal}"
     )
-
-    print(response.json())
 
     assert response.status_code == 200
     assert response.json() == []

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -330,7 +330,7 @@ def test_get_valid_available_image_modal(
 def test_get_valid_unavailable_image_modal(
     test_app, valid_unavailable_image_modal, monkeypatch
 ):
-    """Given a valid, pre-defined, and unavailable image modality, returns a 200 status code and an empty list of results."""
+    """Given a valid, pre-defined, and unavailable image modality, returns a 200 status code and 0 matching subjects."""
 
     async def mock_get(
         age_min,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -7,34 +7,21 @@ from fastapi import HTTPException
 from app.api import crud
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_data():
-    """Create toy data for two subjects for testing."""
-    data = [
+    """Create toy data for two datasets for testing."""
+    return [
         {
-            "number_session": "test1",
-            "modality": "test1",
-            "subject": "test1",
-            "sub_id": "test1",
-            "sex": "test1",
-            "diagnosis": "test1",
-            "dataset_name": "test1",
-            "dataset": "test1",
-            "age": "test1",
+            "dataset": "http://neurobagel.org/vocab/qpn",
+            "dataset_name": "QPN",
+            "num_matching_subjects": 50,
         },
         {
-            "number_session": "test2",
-            "modality": "test2",
-            "subject": "test2",
-            "sub_id": "test2",
-            "sex": "test2",
-            "diagnosis": "test2",
-            "dataset_name": "test2",
-            "dataset": "test2",
-            "age": "test2",
+            "dataset": "http://neurobagel.org/vocab/ppmi",
+            "dataset_name": "PPMI",
+            "num_matching_subjects": 40,
         },
     ]
-    return data
 
 
 @pytest.fixture
@@ -354,14 +341,16 @@ def test_get_valid_unavailable_image_modal(
         min_num_sessions,
         image_modal,
     ):
-        return []
+        return [
+            {"dataset": None, "dataset_name": None, "num_matching_subjects": 0}
+        ]
 
     monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(
         f"/query/?image_modal={valid_unavailable_image_modal}"
     )
     assert response.status_code == 200
-    assert response.json() == []
+    assert response.json()[0]["num_matching_subjects"] == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -341,16 +341,17 @@ def test_get_valid_unavailable_image_modal(
         min_num_sessions,
         image_modal,
     ):
-        return [
-            {"dataset": None, "dataset_name": None, "num_matching_subjects": 0}
-        ]
+        return []
 
     monkeypatch.setattr(crud, "get", mock_get)
     response = test_app.get(
         f"/query/?image_modal={valid_unavailable_image_modal}"
     )
+
+    print(response.json())
+
     assert response.status_code == 200
-    assert response.json()[0]["num_matching_subjects"] == 0
+    assert response.json() == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -75,7 +75,7 @@ def test_get_all(test_app, mock_successful_get, monkeypatch):
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get("/query/")
     assert response.status_code == 200
-    assert response.json() != []
+    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
 
 
 @pytest.mark.parametrize(
@@ -92,7 +92,7 @@ def test_get_valid_age_range(
         f"/query/?age_min={valid_age_min}&age_max={valid_age_max}"
     )
     assert response.status_code == 200
-    assert response.json() != []
+    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
 
 
 @pytest.mark.parametrize(
@@ -107,7 +107,7 @@ def test_get_valid_age_single_bound(
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?{age_keyval}")
     assert response.status_code == 200
-    assert response.json() != []
+    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
 
 
 @pytest.mark.parametrize(
@@ -148,7 +148,7 @@ def test_get_valid_sex(test_app, mock_successful_get, valid_sex, monkeypatch):
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?sex={valid_sex}")
     assert response.status_code == 200
-    assert response.json() != []
+    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
 
 
 def test_get_invalid_sex(test_app, monkeypatch):
@@ -181,7 +181,7 @@ def test_get_valid_diagnosis(
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?diagnosis={valid_diagnosis}")
     assert response.status_code == 200
-    assert response.json() != []
+    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
 
 
 @pytest.mark.parametrize(
@@ -215,7 +215,7 @@ def test_get_valid_iscontrol(
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?is_control={valid_iscontrol}")
     assert response.status_code == 200
-    assert response.json() != []
+    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
 
 
 def test_get_invalid_iscontrol(test_app, monkeypatch):
@@ -273,7 +273,7 @@ def test_get_valid_min_num_sessions(
         f"/query/?min_num_sessions={valid_min_num_sessions}"
     )
     assert response.status_code == 200
-    assert response.json() != []
+    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
 
 
 @pytest.mark.parametrize("invalid_min_num_sessions", [0, -3, "apple"])
@@ -320,7 +320,7 @@ def test_get_valid_available_image_modal(
         f"/query/?image_modal={valid_available_image_modal}"
     )
     assert response.status_code == 200
-    assert response.json() != []
+    assert 0 not in [i["num_matching_subjects"] for i in response.json()]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -70,7 +70,7 @@ def test_app_with_invalid_environment_vars(test_app, monkeypatch):
 
 
 def test_get_all(test_app, mock_successful_get, monkeypatch):
-    """Given no input for the sex parameter, returns a 200 status code and a non-empty list of results (should correspond to all subjects in graph)."""
+    """Given no input for the sex parameter, returns a 200 status code and at least one dataset with subjects (should correspond to all subjects in graph)."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get("/query/")
@@ -85,7 +85,7 @@ def test_get_all(test_app, mock_successful_get, monkeypatch):
 def test_get_valid_age_range(
     test_app, mock_successful_get, valid_age_min, valid_age_max, monkeypatch
 ):
-    """Given a valid age range, returns a 200 status code and a non-empty list of results."""
+    """Given a valid age range, returns a 200 status code and at least one dataset with subjects."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(
@@ -102,7 +102,7 @@ def test_get_valid_age_range(
 def test_get_valid_age_single_bound(
     test_app, mock_successful_get, age_keyval, monkeypatch
 ):
-    """Given only a valid lower/upper age bound, returns a 200 status code and a non-empty list of results."""
+    """Given only a valid lower/upper age bound, returns a 200 status code and at least one dataset with subjects."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?{age_keyval}")
@@ -143,7 +143,7 @@ def test_get_invalid_age(
 
 @pytest.mark.parametrize("valid_sex", ["male", "female", "other"])
 def test_get_valid_sex(test_app, mock_successful_get, valid_sex, monkeypatch):
-    """Given a valid sex string, returns a 200 status code and a non-empty list of results."""
+    """Given a valid sex string, returns a 200 status code and at least one dataset with subjects."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?sex={valid_sex}")
@@ -176,7 +176,7 @@ def test_get_invalid_sex(test_app, monkeypatch):
 def test_get_valid_diagnosis(
     test_app, mock_successful_get, valid_diagnosis, monkeypatch
 ):
-    """Given a valid diagnosis, returns a 200 status code and a non-empty list of results."""
+    """Given a valid diagnosis, returns a 200 status code and at least one dataset with subjects."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?diagnosis={valid_diagnosis}")
@@ -210,7 +210,7 @@ def test_get_invalid_diagnosis(test_app, invalid_diagnosis, monkeypatch):
 def test_get_valid_iscontrol(
     test_app, mock_successful_get, valid_iscontrol, monkeypatch
 ):
-    """Given a valid is_control value, returns a 200 status code and a non-empty list of results."""
+    """Given a valid is_control value, returns a 200 status code and at least one dataset with subjects."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(f"/query/?is_control={valid_iscontrol}")
@@ -266,7 +266,7 @@ def test_get_invalid_control_diagnosis_pair(test_app, monkeypatch):
 def test_get_valid_min_num_sessions(
     test_app, mock_successful_get, valid_min_num_sessions, monkeypatch
 ):
-    """Given a valid minimum number of imaging sessions, returns a 200 status code and a non-empty list of results."""
+    """Given a valid minimum number of imaging sessions, returns a 200 status code and at least one dataset with subjects."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(
@@ -313,7 +313,7 @@ def test_get_invalid_min_num_sessions(
 def test_get_valid_available_image_modal(
     test_app, mock_successful_get, valid_available_image_modal, monkeypatch
 ):
-    """Given a valid and available image modality, returns a 200 status code and a non-empty list of results."""
+    """Given a valid and available image modality, returns a 200 status code and at least one dataset with subjects."""
 
     monkeypatch.setattr(crud, "get", mock_successful_get)
     response = test_app.get(


### PR DESCRIPTION
The main changes are:

- Modified SPARQL query to not return any subject-level phenotypic info
- Created + implemented data model for aggregate responses (dataset, dataset name, number of matching subjects)
- Updated tests to use aggregate responses

Closes #50
Closes #49 
Closes #52
